### PR TITLE
remove remote service link

### DIFF
--- a/appearance/templates/base.html
+++ b/appearance/templates/base.html
@@ -215,9 +215,6 @@
               <li><a href="{{ user.get_absolute_url }}"><i class="fa fa-user"></i> {% trans "Profile" %}</a></li>
               <li><a href="{% url "recent-activity" %}"><i class="fa fa-fire"></i> {% trans "Recent Activity" %}</a></li>
               <li><a href="{% url "messages_inbox" %}"><i class="fa fa-inbox"></i> {% trans "Inbox" %}</a></li>
-              {% if not REGISTRY %}
-              <li><a href="{% url "services" %}"><i class="fa fa-globe"></i> {% trans "Remote Services" %}</a></li>
-              {% endif %}
               {% if USE_NOTIFICATIONS %}
                 <li><a href="{% url "notification_notice_settings" %}"><i class="fa fa-bell"></i> {% trans "Notifications" %}</a></li>
               {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', 'r') as inp:
 
 setup(
     name='django-exchange-themes',
-    version='1.0.1',
+    version='1.0.2',
     author='Boundless Spatial, Maxime Haineault (django-colorfield)',
     author_email='contact@boundlessgeo.com',
     url='https://github.com/boundlessgeo/django-exchange-themes',


### PR DESCRIPTION
removed the services link in the template, also bumped version. This fixes an issue  where a user had a link to add a remote service, which was causing issues in maploom.