### PR TITLE
Update site_base.html to correctly size GEOINT Logo

### DIFF
--- a/appearance/templates/site_base.html
+++ b/appearance/templates/site_base.html
@@ -10,9 +10,12 @@
   <link href="{% static "font-exchange/style.css"%}" rel="stylesheet"/>
   <style>
     {% if theme.banner_logo %}
-        .navbar-brand {
+        a.navbar-brand {
             background-image: url('{{ theme.banner_logo_url }}');
-        }
+            {% ifequal theme.name  "GEOINT" %}
+	        background-size: 30%;
+            {% endifequal %}
+	}
     {% else %}
         .navbar-brand {
             background-image: url('{% static "theme/img/default-banner-logo.svg"%}');


### PR DESCRIPTION
With the latest change to the Exchange core style
the GeoInt logo becomes distorted and doesn't fit
properly on the nav bar like it should. This change
is meant to restyle the logo so it sits correctly.